### PR TITLE
Fix wekan source image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - wekan-db-dump:/dump
 
   wekan:
-    image: quay.io/wekan/wekan:latest
+    image: quay.io/wekan/wekan
     container_name: wekan-app
     restart: always
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - wekan-db-dump:/dump
 
   wekan:
-    image: wekan/wekan-alpine:latest
+    image: quay.io/wekan/wekan:latest
     container_name: wekan-app
     restart: always
     networks:


### PR DESCRIPTION
Since the **v0.7*** the `docker Hub` image is broken and the `wekan` image in the `docker-compose.yml` still point to the docker hub repository.
This PR change the image source with:  `image: quay.io/wekan/wekan:latest`.